### PR TITLE
Reorganize the translation visitor.

### DIFF
--- a/lib/src/xform.dart
+++ b/lib/src/xform.dart
@@ -16,7 +16,7 @@ class AnalysisVisitor extends ast.GeneralizingAstVisitor<bool> {
   bool visit(ast.AstNode node) => node.accept(this);
 
   bool visitNode(ast.AstNode node) {
-    throw 'TODO(${node.runtimeType})';
+    throw 'Unimplemented(${node.runtimeType})';
   }
 
   bool visitCompilationUnit(ast.CompilationUnit node) {
@@ -52,16 +52,15 @@ class AnalysisVisitor extends ast.GeneralizingAstVisitor<bool> {
   }
 
   bool visitBlockFunctionBody(ast.BlockFunctionBody node) {
-    if (node.keyword == null) return false;
-    if (node.star != null) {
-      throw 'TODO(${node.keyword}${node.star})';
-    }
-    return visit(node.block);
+    if (node.isSynchronous || node.isGenerator) return false;
+    visit(node.block);
+    return false;
   }
 
   bool visitExpressionFunctionBody(ast.ExpressionFunctionBody node) {
-    if (node.keyword == null) return false;
-    return visit(node.expression);
+    if (node.isSynchronous || node.isGenerator) return false;
+    visit(node.expression);
+    return false;
   }
 
   bool visitEmptyFunctionBody(ast.EmptyFunctionBody node) {
@@ -371,35 +370,21 @@ ast.MethodInvocation methodInvocation(receiver,
   }
 }
 
-typedef void StatementCont();
-typedef void ReturnCont(ast.Expression expr);
-typedef void DeclarationListCont(List<ast.VariableDeclaration> decls);
-
-typedef void StatementTransformer(ErrorCont f, ReturnCont r, StatementCont s);
-typedef void DeclarationListTransformer(ErrorCont f, DeclarationListCont s);
-
-class AsyncTransformer extends ast.RecursiveAstVisitor<StatementTransformer> {
+class AsyncTransformer extends ast.AstVisitor {
   final Set<ast.AstNode> awaits;
-  AsyncExpressionTransformer expressionTransformer;
 
   ast.Block currentBlock;
+  List<ast.Expression> breakTargets;
+  List<ast.Expression> continueTargets;
 
-  AsyncTransformer(this.awaits) {
-    expressionTransformer = new AsyncExpressionTransformer(this);
-  }
+  AsyncTransformer(this.awaits);
 
   visit(ast.AstNode node) => node.accept(this);
-  ExpressionTransformer visitExpression(ast.Expression expr) {
-    return expressionTransformer.visit(expr);
-  }
 
   int counter = 0;
 
   // TODO: Safely generate fresh identifiers.
   String newName(String base) => '$base${counter++}';
-
-  List<ast.Expression> breakTargets;
-  List<ast.Expression> continueTargets;
 
   /// Insert a declaration with initial value [expr] in [currentBlock] and
   /// return the fresh name.
@@ -425,11 +410,27 @@ class AsyncTransformer extends ast.RecursiveAstVisitor<StatementTransformer> {
     }
   }
 
-  visitNode(ast.AstNode node) {
-    throw 'AsyncTransformer(${node.runtimeType})';
+  ast.FunctionExpression reifyExpressionCont(s, f) {
+    var savedBlock = currentBlock;
+    var exnBlock = currentBlock = emptyBlock();
+    var exnName = newName('e');
+    f(identifier(exnName));
+
+    currentBlock = emptyBlock();
+    var name = newName('x');
+    s(identifier(name));
+
+    var fun =
+        functionExpression(
+            [name],
+            AstFactory.tryStatement2(
+                currentBlock,
+                [AstFactory.catchClause(exnName, exnBlock.statements)]));
+    currentBlock = savedBlock;
+    return fun;
   }
 
-  ast.FunctionExpression reifyErrorCont(ErrorCont f) {
+  ast.FunctionExpression reifyErrorCont(f) {
     var savedBlock = currentBlock;
     currentBlock = emptyBlock();
     String name = newName('e');
@@ -439,7 +440,7 @@ class AsyncTransformer extends ast.RecursiveAstVisitor<StatementTransformer> {
     return fun;
   }
 
-  ast.FunctionExpression reifyStatementCont(StatementCont s) {
+  ast.FunctionExpression reifyStatementCont(s) {
     var savedBlock = currentBlock;
     currentBlock = emptyBlock();
     s();
@@ -448,7 +449,9 @@ class AsyncTransformer extends ast.RecursiveAstVisitor<StatementTransformer> {
     return fun;
   }
 
+  // ---- CompilationUnit ----
   visitCompilationUnit(ast.CompilationUnit node) {
+    // TODO(kmillikin): import 'dart:async' if necessary.
     return new ast.CompilationUnit(
         node.beginToken,
         node.scriptTag,
@@ -457,6 +460,7 @@ class AsyncTransformer extends ast.RecursiveAstVisitor<StatementTransformer> {
         node.endToken);
   }
 
+  // ---- CompilationUnitMembers ----
   visitClassDeclaration(ast.ClassDeclaration node) {
     return new ast.ClassDeclaration(
         node.documentationComment,
@@ -473,6 +477,28 @@ class AsyncTransformer extends ast.RecursiveAstVisitor<StatementTransformer> {
         node.rightBracket);
   }
 
+  visitClassTypeAlias(ast.ClassTypeAlias node) {
+    return node;
+  }
+
+  visitEnumDeclaration(ast.EnumDeclaration node) {
+    return node;
+  }
+
+  visitFunctionDeclaration(ast.FunctionDeclaration node) {
+    node.functionExpression.body = visit(node.functionExpression.body);
+    return node;
+  }
+
+  visitFunctionTypeAlias(ast.FunctionTypeAlias node) {
+    return node;
+  }
+
+  visitTopLevelVariableDeclaration(ast.TopLevelVariableDeclaration node) {
+    return node;
+  }
+
+  // ---- ClassMembers ----
   visitConstructorDeclaration(ast.ConstructorDeclaration node) {
     return node;
   }
@@ -486,33 +512,15 @@ class AsyncTransformer extends ast.RecursiveAstVisitor<StatementTransformer> {
     return node;
   }
 
-  visitTopLevelVariableDeclaration(ast.TopLevelVariableDeclaration node) {
-    return node;
-  }
-
-  visitFunctionDeclaration(ast.FunctionDeclaration node) {
-    return new ast.FunctionDeclaration(
-        node.documentationComment,
-        node.metadata,
-        node.externalKeyword,
-        node.returnType,
-        node.propertyKeyword,
-        node.name,
-        new ast.FunctionExpression(
-            node.functionExpression.parameters,
-            visit(node.functionExpression.body)));
-  }
-
+  // ---- FunctionBodies ----
   visitBlockFunctionBody(ast.BlockFunctionBody node) {
-    if (node.keyword == null) return node;
-    if (node.star != null) {
-      throw 'TODO(${node.keyword}${node.star})';
-    }
+    if (node.isSynchronous || node.isGenerator) return node;
+
     counter = 0;
     currentBlock = emptyBlock();
     breakTargets = <ast.Expression>[];
     continueTargets = <ast.Expression>[];
-    var result = newName('result');
+    var result = newName('completer');
     visit(node.block)((e) {
       addStatement(methodInvocation(result, 'completeError', [e]));
     }, (v) {
@@ -547,129 +555,57 @@ class AsyncTransformer extends ast.RecursiveAstVisitor<StatementTransformer> {
               AstFactory.propertyAccess2(identifier(result), 'future'))]);
   }
 
+  visitEmptyFunctionBody(ast.EmptyFunctionBody node) {
+    return node;
+  }
+
   visitExpressionFunctionBody(ast.ExpressionFunctionBody node) {
-    if (node.keyword == null) return node;
+    if (node.isSynchronous || node.isGenerator) return node;
     return visit(AstFactory.blockFunctionBody2(
         [AstFactory.returnStatement2(node.expression)])
         ..keyword = node.keyword);
   }
 
-  visitEmptyFunctionBody(ast.EmptyFunctionBody node) {
+  visitNativeFunctionBody(ast.NativeFunctionBody node) {
     return node;
   }
 
-  visitFunctionTypeAlias(ast.FunctionTypeAlias node) {
-    return node;
-  }
+  // ---- Statements ----
+  unimplemented(ast.AstNode node) => throw 'Unimplemented(${node.runtimeType})';
+  visitAssertStatement(ast.AssertStatement node) => unimplemented(node);
 
-  visitCatchClause(ast.CatchClause node) => (f, r, s) {
-    return visit(node.body)(f, r, s);
+  visitBlock(ast.Block node) => (f, r, s) {
+    for (var stmt in node.statements.reversed) {
+      var nextCont = s;
+      s = () => visit(stmt)(f, r, nextCont);
+    }
+    return s();
   };
 
-  visitVariableDeclarationList(ast.VariableDeclarationList node) {
-    return new ast.VariableDeclarationList(
-        node.documentationComment,
-        node.metadata,
-        node.keyword,
-        node.type,
-        node.variables.map(visit).toList(growable: false));
-  }
+  visitBreakStatement(ast.BreakStatement node) => (f, r, s) {
+    if (node.label != null) unimplemented(node);
+    addStatement(AstFactory.functionExpressionInvocation(
+        breakTargets.last, [nullLiteral()]));
+  };
 
-  void residualizeDeclarationList(scanner.Keyword keyword,
-                                  List<ast.VariableDeclaration> decls) {
-    if (decls.isEmpty) return;
-    addStatement(AstFactory.variableDeclarationStatement2(keyword, decls));
-  }
+  visitContinueStatement(ast.ContinueStatement node) => (f, r, s) {
+    if (node.label != null) unimplemented(node);
+    addStatement(AstFactory.functionExpressionInvocation(
+            continueTargets.last, [nullLiteral()]));
+  };
 
-  DeclarationListTransformer translateDeclarationList(
-      scanner.Keyword keyword,
-      ast.VariableDeclarationList node) {
-    assert(node.variables.isNotEmpty);
-    return (ErrorCont f, DeclarationListCont s) {
-      translateDecl(ast.VariableDeclaration decl, cont) {
-        if (decl.initializer == null) {
-          return cont(decl);
-        } else {
-          return visitExpression(decl.initializer)(f, (expr) {
-            return cont(AstFactory.variableDeclaration2(decl.name.name, expr));
-          });
-        }
-      }
+  visitDoStatement(ast.DoStatement node) => (f, r, s) {
+    var breakName = newName('break');
+    var continueName = newName('continue');
+    var loopName = newName('loop');
 
-      var decls = [];
-      // The continuation for the last declaration.
-      var cont = (decl) {
-        decls.add(decl);
-        return s(decls);
-      };
-      for (var i = node.variables.length - 1; i >= 1; --i) {
-        var nextCont = cont;
-        // The continuation for the i-1 declaration.
-        cont = (decl) {
-          decls.add(decl);
-          var nextDecl = node.variables[i];
-          if (awaits.contains(nextDecl)) {
-            residualizeDeclarationList(keyword, decls);
-            decls.clear();
-          }
-          translateDecl(nextDecl, nextCont);
-        };
-      }
-      translateDecl(node.variables.first, cont);
-    };
-  }
+    var savedBlock = currentBlock;
+    var breakBlock = currentBlock = emptyBlock();
+    s();
 
-  visitVariableDeclaration(ast.VariableDeclaration node) {
-    return new ast.VariableDeclaration(
-        node.documentationComment,
-        node.metadata,
-        node.name,
-        node.equals,
-        visit(node.initializer));
-  }
-
-  // Statements
-  StatementTransformer visitBlock(ast.Block node) {
-    return (ErrorCont f, ReturnCont r, StatementCont s) {
-      for (var stmt in node.statements.reversed) {
-        var current = s;
-        s = () {
-          return visit(stmt)(f, r, current);
-        };
-      }
-      return s();
-    };
-  }
-
-  StatementTransformer visitBreakStatement(ast.BreakStatement node) {
-    return (ErrorCont f, ReturnCont r, StatementCont s) {
-      addStatement(
-          AstFactory.functionExpressionInvocation(
-              breakTargets.last, [nullLiteral()]));
-    };
-  }
-
-  StatementTransformer visitContinueStatement(ast.ContinueStatement node) {
-    return (ErrorCont f, ReturnCont r, StatementCont s) {
-      addStatement(
-          AstFactory.functionExpressionInvocation(
-              continueTargets.last, [nullLiteral()]));
-    };
-  }
-
-  StatementTransformer visitDoStatement(ast.DoStatement node) {
-    return (ErrorCont f, ReturnCont r, StatementCont s) {
-      var breakName = newName('break');
-      var continueName = newName('continue');
-      var loopName = newName('loop');
-
-      var savedBlock = currentBlock;
-      var breakBlock = currentBlock = emptyBlock();
-      s();
-
-      var continueBlock = currentBlock = emptyBlock();
-      visitExpression(node.condition)(f, (expr) {
-        addStatement(AstFactory.ifStatement2(
+    var continueBlock = currentBlock = emptyBlock();
+    visit(node.condition)(f, (expr) {
+      addStatement(AstFactory.ifStatement2(
           expr,
           block([AstFactory.methodInvocation(
               AstFactory.functionExpressionInvocation(
@@ -680,195 +616,46 @@ class AsyncTransformer extends ast.RecursiveAstVisitor<StatementTransformer> {
               [identifier(loopName)])]),
           block([AstFactory.functionExpressionInvocation(
               identifier(breakName), [nullLiteral()])])));
-      });
+    });
 
-      var loopBlock = currentBlock = emptyBlock();
-      addStatement(
-          AstFactory.functionDeclarationStatement(null, null, continueName,
-              functionExpression(['_'], continueBlock)));
-      breakTargets.add(identifier(breakName));
-      continueTargets.add(identifier(continueName));
-      visit(node.body)(f, r, () {
-        addStatement(
-            AstFactory.functionExpressionInvocation(
-                identifier(continueName), [nullLiteral()]));
-      });
-      breakTargets.removeLast();
-      continueTargets.removeLast();
-
-      currentBlock = savedBlock;
-      addStatement(
-          AstFactory.functionDeclarationStatement(null, null, breakName,
-              functionExpression(['_'], breakBlock)));
-      addStatement(
-          AstFactory.functionDeclarationStatement(null, null, loopName,
-              functionExpression(['_'], loopBlock)));
+    var loopBlock = currentBlock = emptyBlock();
+    addStatement(
+        AstFactory.functionDeclarationStatement(null, null, continueName,
+            functionExpression(['_'], continueBlock)));
+    breakTargets.add(identifier(breakName));
+    continueTargets.add(identifier(continueName));
+    visit(node.body)(f, r, () {
       addStatement(
           AstFactory.functionExpressionInvocation(
-              identifier(loopName), [nullLiteral()]));
-    };
-  }
-
-  StatementTransformer visitExpressionStatement(ast.ExpressionStatement node) {
-    return (ErrorCont f, ReturnCont r, StatementCont s) {
-      return visitExpression(node.expression)(f, (expr) {
-        addStatement(expr);
-        return s();
-      });
-    };
-  }
-
-  StatementTransformer visitForStatement(ast.ForStatement node) {
-    translateUpdaters(List<ast.Expression> exprs, ErrorCont f,
-        StatementCont s) {
-      var cont = s;
-      for (int i = exprs.length - 1; i >= 0; --i) {
-        var nextCont = cont;
-        cont = () {
-          visitExpression(exprs[i])(f, (expr) {
-            addStatement(expr);
-            return nextCont();
-          });
-        };
-      }
-      return cont();
-    }
-
-    translateDeclarations(List<ast.VariableDeclaration> decls,
-        ErrorCont f, ExpressionListCont s) {
-      var exprs = [];
-      var seenAwait = false;
-      var cont = (e) {
-        exprs.add(e);
-        return s(exprs);
-      };
-      for (var i = decls.length - 1; i >= 1; --i) {
-        // Build the continuation for the i-1 initializer expression.
-        var nextExpr = decls[i].initializer;
-        if (nextExpr != null) {
-          seenAwait = seenAwait || awaits.contains(nextExpr);
-        }
-        var nextCont = cont;
-        if (nextExpr == null) {
-          cont = (e) {
-            exprs.add(e);
-            nextCont(nullLiteral());
-          };
-        } else if (seenAwait) {
-          cont = (e) {
-            var value = addDeclaration('v', e);
-            exprs.add(value);
-            visitExpression(nextExpr)(f, nextCont);
-          };
-        } else {
-          cont = (e) {
-            exprs.add(e);
-            visitExpression(nextExpr)(f, nextCont);
-          };
-        }
-      }
-      var expr = decls.first.initializer;
-      if (expr == null) {
-        return cont(nullLiteral());
-      } else {
-        return visitExpression(expr)(f, cont);
-      }
-    }
-
-    return (ErrorCont f, ReturnCont r, StatementCont s) {
-      var breakName = newName('break');
-      var continueName = newName('continue');
-      var loopName = newName('loop');
-
-      var savedBlock = currentBlock;
-      var breakBlock = currentBlock = emptyBlock();
-      s();
-
-      var parameters;
-      if (node.variables != null) {
-        parameters = node.variables.variables.map((d) => d.name).toList();
-      } else {
-        parameters = <ast.SimpleIdentifier>[];
-      }
-
-      var continueBlock = currentBlock = emptyBlock();
-      trampoline() {
-        addStatement(
-            AstFactory.methodInvocation(
-                AstFactory.functionExpressionInvocation(
-                    AstFactory.identifier(identifier('Future'),
-                                          identifier('wait')),
-                    [AstFactory.listLiteral([])]),
-                'then',
-                [functionExpression (['_'],
-                    AstFactory.functionExpressionInvocation(
-                        identifier(loopName),
-                        parameters))]));
-      }
-      if (node.updaters != null) {
-        translateUpdaters(node.updaters, f, trampoline);
-      } else {
-        trampoline();
-      }
-
-      var bodyBlock = currentBlock = emptyBlock();
-      breakTargets.add(identifier(breakName));
-      continueTargets.add(identifier(continueName));
-      visit(node.body)(f, r, () {
-        addStatement(
-            AstFactory.functionExpressionInvocation(
               identifier(continueName), [nullLiteral()]));
-      });
-      breakTargets.removeLast();
-      continueTargets.removeLast();
+    });
+    breakTargets.removeLast();
+    continueTargets.removeLast();
 
-      var loopBlock = currentBlock = emptyBlock();
-      addStatement(
-          AstFactory.functionDeclarationStatement(null, null, continueName,
-              functionExpression(['_'], continueBlock)));
-      if (node.condition != null) {
-        visitExpression(node.condition)(f, (expr) {
-          addStatement(AstFactory.ifStatement2(
-            expr,
-            bodyBlock,
-            block([AstFactory.functionExpressionInvocation(
-                identifier(breakName), [nullLiteral()])])));
-        });
-      } else {
-        addStatement(bodyBlock);
-      }
+    currentBlock = savedBlock;
+    addStatement(
+        AstFactory.functionDeclarationStatement(null, null, breakName,
+            functionExpression(['_'], breakBlock)));
+    addStatement(
+        AstFactory.functionDeclarationStatement(null, null, loopName,
+            functionExpression(['_'], loopBlock)));
+    addStatement(
+        AstFactory.functionExpressionInvocation(
+            identifier(loopName), [nullLiteral()]));
+  };
 
-      currentBlock = savedBlock;
-      addStatement(
-          AstFactory.functionDeclarationStatement(null, null, breakName,
-              functionExpression(['_'], breakBlock)));
-      addStatement(
-          AstFactory.functionDeclarationStatement(null, null, loopName,
-              functionExpression(parameters.map((e) => e.name).toList(),
-                  loopBlock)));
-      if (node.variables != null) {
-        assert(node.variables.variables.isNotEmpty);
-        return translateDeclarations(node.variables.variables, f, (args) {
-          assert(args.length == parameters.length);
-          addStatement(AstFactory.functionExpressionInvocation(
-              identifier(loopName), args));
-        });
-      } else if (node.initialization != null) {
-        assert(parameters.isEmpty);
-        return visitExpression(node.initialization)(f, (expr) {
-          addStatement(expr);
-          addStatement(AstFactory.functionExpressionInvocation(
-              identifier(loopName), []));
-        });
-      } else {
-        assert(parameters.isEmpty);
-        return addStatement(AstFactory.functionExpressionInvocation(
-            identifier(loopName), []));
-      }
-    };
-  }
+  visitEmptyStatement(ast.EmptyStatement node) => (f, r, s) {
+    return s();
+  };
 
-  StatementTransformer visitForEachStatement(ast.ForEachStatement node) {
+  visitExpressionStatement(ast.ExpressionStatement node) => (f, r, s) {
+    return visit(node.expression)(f, (expr) {
+      addStatement(expr);
+      return s();
+    });
+  };
+
+  visitForEachStatement(ast.ForEachStatement node) {
     var stmt = emptyBlock();
     var it = newName('it');
     stmt.statements.add(
@@ -897,518 +684,677 @@ class AsyncTransformer extends ast.RecursiveAstVisitor<StatementTransformer> {
     stmt.statements.add(AstFactory.whileStatement(
         AstFactory.methodInvocation(identifier(it), 'moveNext', []),
         body));
-    return visit(stmt);
+    return visitBlock(stmt);
   }
 
-  StatementTransformer visitIfStatement(ast.IfStatement node) {
-    return (ErrorCont f, ReturnCont r, StatementCont s) {
-      var hasElse = node.elseStatement != null;
-      return visitExpression(node.condition)(f, (expr) {
-        var joinName = newName('join');
-        var joinFun = reifyStatementCont(s);
-        addStatement(
-            AstFactory.functionDeclarationStatement(
-                null, null, joinName, joinFun));
-        s = () {
-          addStatement(AstFactory.methodInvocation2(joinName, []));
-        };
-        var savedBlock = currentBlock;
-        var thenBlock = currentBlock = emptyBlock();
-        visit(node.thenStatement)(f, r, s);
-        var elseBlock = currentBlock = emptyBlock();
-        if (hasElse) {
-          visit(node.elseStatement)(f, r, s);
-        } else {
-          s();
-        }
-        currentBlock = savedBlock;
-        addStatement(AstFactory.ifStatement2(expr, thenBlock, elseBlock));
-      });
-    };
-  }
-
-  StatementTransformer visitReturnStatement(ast.ReturnStatement node) {
-    return (ErrorCont f, ReturnCont r, StatementCont s) {
-      if (node.expression == null) {
-        return r(AstFactory.nullLiteral());
-      } else {
-        return visitExpression(node.expression)(f, (v) => r(v));
-      }
-    };
-  }
-
-  StatementTransformer visitTryStatement(ast.TryStatement node) {
-    return (ErrorCont f, ReturnCont r, StatementCont s) {
-      var joinName = newName('join');
-      ast.FunctionExpression joinFun = reifyStatementCont(s);
-      joinFun.parameters = AstFactory.formalParameterList(
-          [AstFactory.simpleFormalParameter3('_')]);
-      addStatement(
-          AstFactory.functionDeclarationStatement(null, null, joinName, joinFun));
-
-      var finallyName = newName('finally');
-      var finallyContName = newName('cont');
-      var finallyValueName = newName('v');
-      var savedBlock = currentBlock;
-      var finallyBlock = currentBlock = emptyBlock();
-      s = () {
-        addStatement(AstFactory.functionExpressionInvocation(
-                identifier(finallyContName),
-                [identifier(finallyValueName)]));
+  _translateForUpdaters(List<ast.Expression> exprs, f, s) {
+    var cont = s;
+    for (var expr in exprs.reversed) {
+      var nextCont = cont;
+      cont = () {
+        visit(expr)(f, (expr) {
+          addStatement(expr);
+          return nextCont();
+        });
       };
-      if (node.finallyBlock != null) {
-        visit(node.finallyBlock)(f, r, s);
-      } else {
-        s();
-      }
+     }
+     return cont();
+   }
 
-      var catchName = newName('catch');
-      var exnName = node.catchClauses.isEmpty ?
-          newName('e') :
-          node.catchClauses.first.exceptionParameter.name;
-      var catchBlock = currentBlock = emptyBlock();
-      var savedBreakTargets = breakTargets;
-      var savedContinueTargets = continueTargets;
-      breakTargets = breakTargets.map((expr) {
-        return AstFactory.parenthesizedExpression(
-                functionExpression(['_'],
-                    AstFactory.functionExpressionInvocation(
-                        identifier(finallyName), [expr, identifier('_')])));
-      }).toList();
-      continueTargets = continueTargets.map((expr) {
-        return AstFactory.parenthesizedExpression(
-            functionExpression(['_'],
-                AstFactory.functionExpressionInvocation(
-                    identifier(finallyName), [expr, identifier('_')])));
-      }).toList();
-      if (node.catchClauses.isNotEmpty) {
-        assert(node.catchClauses.length == 1);
-        visit(node.catchClauses.first)((e) {
-          addStatement(
-              AstFactory.methodInvocation2(finallyName, [reifyErrorCont(f), e]));
-        }, (v) {
-          addStatement(
-              AstFactory.methodInvocation2(finallyName, [reifyErrorCont(r), v]));
-        }, () {
-          addStatement(
-              AstFactory.methodInvocation2(
-                  finallyName,
-                  [identifier(joinName), AstFactory.nullLiteral()]));
-        });
-      } else {
-        addStatement(
-            AstFactory.methodInvocation2(
-                finallyName,
-                [identifier(joinName), AstFactory.nullLiteral()]));
-      }
-
-      var tryBlock = currentBlock = emptyBlock();
-      visit(node.body)((e) {
-        addStatement(AstFactory.methodInvocation2(catchName, [e]));
-      }, (v) {
-        addStatement(
-            AstFactory.methodInvocation2(finallyName, [reifyErrorCont(r), v]));
-      }, () {
-        addStatement(
-            AstFactory.expressionStatement(
-                AstFactory.methodInvocation2(
-                    finallyName,
-                    [identifier(joinName), AstFactory.nullLiteral()])));
-      });
-
-      currentBlock = savedBlock;
-      breakTargets = savedBreakTargets;
-      continueTargets = savedContinueTargets;
-      addStatement(
-          AstFactory.functionDeclarationStatement(
-              null,
-              null,
-              finallyName,
-              functionExpression([finallyContName, finallyValueName], finallyBlock)));
-
-      addStatement(
-          AstFactory.functionDeclarationStatement(
-              null,
-              null,
-              catchName,
-              functionExpression([exnName], catchBlock)));
-      var name = newName('e');
-      addStatement(
-          AstFactory.tryStatement2(
-              tryBlock,
-              [AstFactory.catchClause(
-                    name,
-                    [AstFactory.expressionStatement(
-                          AstFactory.methodInvocation2(
-                              catchName, [identifier(name)]))])]));
+  _translateForDeclarations(List<ast.VariableDeclaration> decls, f, s) {
+    var exprs = [];
+    var seenAwait = false;
+    var cont = (e) {
+      exprs.add(e);
+      return s(exprs);
     };
+    for (var i = decls.length - 1; i >= 1; --i) {
+      // Build the continuation for the i-1 initializer expression.
+      var nextExpr = decls[i].initializer;
+      if (nextExpr != null) {
+        seenAwait = seenAwait || awaits.contains(nextExpr);
+      }
+      var nextCont = cont;
+      var copiedSeenAwait = seenAwait;
+      cont = (e) {
+        if (copiedSeenAwait) e = addDeclaration('v', e);
+        exprs.add(e);
+        return (nextExpr == null)
+            ? nextCont(nullLiteral())
+            : visit(nextExpr)(f, nextCont);
+      };
+    }
+    var expr = decls.first.initializer;
+    return (expr == null)
+        ? cont(nullLiteral())
+        :  visit(expr)(f, cont);
   }
 
-  StatementTransformer visitVariableDeclarationStatement(
-      ast.VariableDeclarationStatement node) {
-    return (ErrorCont f, ReturnCont r, StatementCont s) {
-      var keyword = scanner.Keyword.keywords[node.variables.keyword.lexeme];
-      return translateDeclarationList(keyword, node.variables)(f, (decls) {
-        residualizeDeclarationList(keyword, decls);
-        return s();
-      });
-    };
-  }
+ visitForStatement(ast.ForStatement node) => (f, r, s) {
+    var breakName = newName('break');
+    var continueName = newName('continue');
+    var loopName = newName('loop');
 
-  StatementTransformer visitWhileStatement(ast.WhileStatement node) {
-    return (ErrorCont f, ReturnCont r, StatementCont s) {
-      var breakName = newName('break');
-      var continueName = newName('continue');
+    var savedBlock = currentBlock;
+    var breakBlock = currentBlock = emptyBlock();
+    s();
 
-      var savedBlock = currentBlock;
-      var breakBlock = currentBlock = emptyBlock();
-      s();
+    var parameters;
+    if (node.variables != null) {
+      parameters = node.variables.variables.map((d) => d.name).toList();
+    } else {
+      parameters = <ast.SimpleIdentifier>[];
+    }
 
-      var continueBlock = currentBlock = emptyBlock();
-      visitExpression(node.condition)(f, (expr) {
-        var savedBlock = currentBlock;
-        var bodyBlock = currentBlock = emptyBlock();
-        breakTargets.add(identifier(breakName));
-        continueTargets.add(identifier(continueName));
-        visit(node.body)(f, r, () {
-          addStatement(
-              AstFactory.functionExpressionInvocation(
-                identifier(continueName), [nullLiteral()]));
-        });
-        breakTargets.removeLast();
-        continueTargets.removeLast();
-
-        currentBlock = savedBlock;
-        addStatement(AstFactory.ifStatement2(
-          expr,
-          // Trampoline the body via Future.wait.
-          block([AstFactory.methodInvocation(
+    var continueBlock = currentBlock = emptyBlock();
+    trampoline() {
+      addStatement(
+          AstFactory.methodInvocation(
               AstFactory.functionExpressionInvocation(
                   AstFactory.identifier(identifier('Future'),
                                         identifier('wait')),
                   [AstFactory.listLiteral([])]),
               'then',
-              [functionExpression(['_'], bodyBlock)])]),
-          block([AstFactory.functionExpressionInvocation(
-              identifier(breakName), [nullLiteral()])])));
-      });
+              [functionExpression (['_'],
+                  AstFactory.functionExpressionInvocation(
+                      identifier(loopName),
+                      parameters))]));
+    }
+    if (node.updaters != null) {
+      _translateForUpdaters(node.updaters, f, trampoline);
+    } else {
+      trampoline();
+    }
 
-      currentBlock = savedBlock;
-      addStatement(
-          AstFactory.functionDeclarationStatement(null, null, breakName,
-              functionExpression(['_'], breakBlock)));
-      addStatement(
-          AstFactory.functionDeclarationStatement(null, null, continueName,
-              functionExpression(['_'], continueBlock)));
+    var bodyBlock = currentBlock = emptyBlock();
+    breakTargets.add(identifier(breakName));
+    continueTargets.add(identifier(continueName));
+    visit(node.body)(f, r, () {
       addStatement(
           AstFactory.functionExpressionInvocation(
               identifier(continueName), [nullLiteral()]));
-    };
-  }
-}
+    });
+    breakTargets.removeLast();
+    continueTargets.removeLast();
 
-typedef void ExpressionCont(ast.Expression expr);
-typedef void ExpressionListCont(List<ast.Expression> exprs);
-typedef void ErrorCont(ast.Expression expr);
-
-typedef void ExpressionTransformer(ErrorCont f, ExpressionCont s);
-typedef void ExpressionListTransformer(ErrorCont f, ExpressionListCont s);
-
-class AsyncExpressionTransformer extends
-    ast.GeneralizingAstVisitor<ExpressionTransformer> {
-  final AsyncTransformer owner;
-
-  AsyncExpressionTransformer(this.owner);
-
-  ast.Block get currentBlock => owner.currentBlock;
-  set currentBlock(ast.Block block) {
-    owner.currentBlock = block;
-  }
-
-  Set<ast.AstNode> get awaits => owner.awaits;
-
-  visit(ast.Expression node) => node.accept(this);
-
-  ExpressionTransformer visitNode(ast.AstNode node) {
-    throw 'AsyncExpressionTransformer(${node.runtimeType})';
-  }
-
-  ast.FunctionExpression reifyExpressionCont(ExpressionCont s, ErrorCont f) {
-    var savedBlock = currentBlock;
-    var exnBlock = currentBlock = emptyBlock();
-    var exnName = owner.newName('e');
-    f(identifier(exnName));
-
-    currentBlock = emptyBlock();
-    var name = owner.newName('x');
-    s(identifier(name));
-
-    var fun =
-        functionExpression(
-            [name],
-            AstFactory.tryStatement2(
-                currentBlock,
-                [AstFactory.catchClause(exnName, exnBlock.statements)]));
-    currentBlock = savedBlock;
-    return fun;
-  }
-
-  ExpressionListTransformer translateExpressionList(
-        ast.NodeList<ast.Expression> exprs) {
-    return (ErrorCont f, ExpressionListCont s) {
-      if (exprs.isEmpty) {
-        return s([]);
-      }
-      var args = [];
-      var seenAwait = false;
-      var cont = (v) {
-        args.add(v);
-        return s(args);
-      };
-      for (var i = exprs.length - 1; i >= 1; --i) {
-        var expr = exprs[i];
-        seenAwait = seenAwait || awaits.contains(expr);
-        var current = cont;
-        if (seenAwait) {
-          cont = (v) {
-            var value = owner.addDeclaration('v', v);
-            args.add(value);
-            visit(expr)(f, current);
-          };
-        } else {
-          cont = (v) {
-            args.add(v);
-            visit(expr)(f, current);
-          };
-        }
-      }
-      return visit(exprs.first)(f, cont);
-    };
-  }
-
-  ExpressionTransformer visitAssignmentExpression(
-      ast.AssignmentExpression node) {
-    assert(node.leftHandSide is ast.SimpleIdentifier);
-    return (ErrorCont f, ExpressionCont s) {
-      visit(node.rightHandSide)(f, (expr) {
-        return s(AstFactory.assignmentExpression(
-            node.leftHandSide, node.operator.type, expr));
+    var loopBlock = currentBlock = emptyBlock();
+    addStatement(
+        AstFactory.functionDeclarationStatement(null, null, continueName,
+            functionExpression(['_'], continueBlock)));
+    if (node.condition != null) {
+      visit(node.condition)(f, (expr) {
+        addStatement(AstFactory.ifStatement2(
+          expr,
+          bodyBlock,
+          block([AstFactory.functionExpressionInvocation(
+              identifier(breakName), [nullLiteral()])])));
       });
-    };
+    } else {
+      addStatement(bodyBlock);
+    }
+
+    currentBlock = savedBlock;
+    addStatement(
+        AstFactory.functionDeclarationStatement(null, null, breakName,
+            functionExpression(['_'], breakBlock)));
+    addStatement(
+        AstFactory.functionDeclarationStatement(null, null, loopName,
+            functionExpression(parameters.map((e) => e.name).toList(),
+                loopBlock)));
+    if (node.variables != null) {
+      assert(node.variables.variables.isNotEmpty);
+      return _translateForDeclarations(node.variables.variables, f, (args) {
+        assert(args.length == parameters.length);
+        addStatement(AstFactory.functionExpressionInvocation(
+            identifier(loopName), args));
+      });
+    } else if (node.initialization != null) {
+      assert(parameters.isEmpty);
+      return visit(node.initialization)(f, (expr) {
+        addStatement(expr);
+        addStatement(AstFactory.functionExpressionInvocation(
+            identifier(loopName), []));
+      });
+    } else {
+      assert(parameters.isEmpty);
+      return addStatement(AstFactory.functionExpressionInvocation(
+          identifier(loopName), []));
+    }
+  };
+
+  visitFunctionDeclarationStatement(ast.FunctionDeclarationStatement node) {
+    return unimplemented(node);
   }
 
-  ExpressionTransformer visitAwaitExpression(ast.AwaitExpression node) {
-    return (ErrorCont f, ExpressionCont s) {
-      if (awaits.contains(node.expression)) {
-        visit(node.expression)(f, (expr) {
-          owner.addStatement(
-              AstFactory.methodInvocation(
-                  expr,
-                  'then',
-                  [reifyExpressionCont(s, f),
-                    AstFactory.namedExpression2('onError', owner.reifyErrorCont(f))]));
-        });
+  visitIfStatement(ast.IfStatement node) => (f, r, s) {
+    var hasElse = node.elseStatement != null;
+    return visit(node.condition)(f, (expr) {
+      var joinName = newName('join');
+      var joinFun = reifyStatementCont(s);
+      addStatement(
+          AstFactory.functionDeclarationStatement(
+              null, null, joinName, joinFun));
+      s = () {
+        addStatement(AstFactory.methodInvocation2(joinName, []));
+      };
+      var savedBlock = currentBlock;
+      var thenBlock = currentBlock = emptyBlock();
+      visit(node.thenStatement)(f, r, s);
+      var elseBlock = currentBlock = emptyBlock();
+      if (hasElse) {
+        visit(node.elseStatement)(f, r, s);
       } else {
-        owner.addStatement(
+        s();
+      }
+      currentBlock = savedBlock;
+      addStatement(AstFactory.ifStatement2(expr, thenBlock, elseBlock));
+    });
+  };
+
+  visitLabeledStatement(ast.LabeledStatement node) => unimplemented(node);
+
+  visitRethrowExpression(ast.RethrowExpression node) => unimplemented(node);
+
+  visitReturnStatement(ast.ReturnStatement node) => (f, r, s) {
+    return (node.expression == null)
+        ? r(AstFactory.nullLiteral())
+        : visit(node.expression)(f, (v) => r(v));
+  };
+
+  visitSwitchStatement(ast.SwitchStatement node) => unimplemented(node);
+
+  visitCatchClause(ast.CatchClause node) => (f, r, s) {
+    // TODO(kmillikin): handle 'on T catch' clauses.
+    return visit(node.body)(f, r, s);
+  };
+
+  visitTryStatement(ast.TryStatement node) => (f, r, s) {
+    var joinName = newName('join');
+    ast.FunctionExpression joinFun = reifyStatementCont(s);
+    joinFun.parameters = AstFactory.formalParameterList(
+        [AstFactory.simpleFormalParameter3('_')]);
+    addStatement(
+        AstFactory.functionDeclarationStatement(null, null, joinName, joinFun));
+
+    var finallyName = newName('finally');
+    var finallyContName = newName('cont');
+    var finallyValueName = newName('v');
+    var savedBlock = currentBlock;
+    var finallyBlock = currentBlock = emptyBlock();
+    s = () {
+      addStatement(AstFactory.functionExpressionInvocation(
+              identifier(finallyContName),
+              [identifier(finallyValueName)]));
+    };
+    if (node.finallyBlock != null) {
+      visit(node.finallyBlock)(f, r, s);
+    } else {
+      s();
+    }
+
+    var catchName = newName('catch');
+    var exnName = node.catchClauses.isEmpty ?
+        newName('e') :
+        node.catchClauses.first.exceptionParameter.name;
+    var catchBlock = currentBlock = emptyBlock();
+    var savedBreakTargets = breakTargets;
+    var savedContinueTargets = continueTargets;
+    breakTargets = breakTargets.map((expr) {
+      return AstFactory.parenthesizedExpression(
+              functionExpression(['_'],
+                  AstFactory.functionExpressionInvocation(
+                      identifier(finallyName), [expr, identifier('_')])));
+    }).toList();
+    continueTargets = continueTargets.map((expr) {
+      return AstFactory.parenthesizedExpression(
+          functionExpression(['_'],
+               AstFactory.functionExpressionInvocation(
+                  identifier(finallyName), [expr, identifier('_')])));
+    }).toList();
+    if (node.catchClauses.isNotEmpty) {
+      assert(node.catchClauses.length == 1);
+      visit(node.catchClauses.first)((e) {
+        addStatement(
+            AstFactory.methodInvocation2(finallyName, [reifyErrorCont(f), e]));
+      }, (v) {
+        addStatement(
+            AstFactory.methodInvocation2(finallyName, [reifyErrorCont(r), v]));
+      }, () {
+        addStatement(
+            AstFactory.methodInvocation2(
+                finallyName,
+                [identifier(joinName), AstFactory.nullLiteral()]));
+      });
+    } else {
+      addStatement(
+          AstFactory.methodInvocation2(
+              finallyName,
+              [identifier(joinName), AstFactory.nullLiteral()]));
+    }
+
+    var tryBlock = currentBlock = emptyBlock();
+    visit(node.body)((e) {
+      addStatement(AstFactory.methodInvocation2(catchName, [e]));
+    }, (v) {
+      addStatement(
+          AstFactory.methodInvocation2(finallyName, [reifyErrorCont(r), v]));
+    }, () {
+      addStatement(
+          AstFactory.expressionStatement(
+              AstFactory.methodInvocation2(
+                  finallyName,
+                  [identifier(joinName), AstFactory.nullLiteral()])));
+    });
+
+    currentBlock = savedBlock;
+    breakTargets = savedBreakTargets;
+    continueTargets = savedContinueTargets;
+    addStatement(
+        AstFactory.functionDeclarationStatement(
+            null,
+            null,
+            finallyName,
+            functionExpression([finallyContName, finallyValueName], finallyBlock)));
+
+    addStatement(
+        AstFactory.functionDeclarationStatement(
+            null,
+            null,
+            catchName,
+            functionExpression([exnName], catchBlock)));
+    var name = newName('e');
+    addStatement(
+        AstFactory.tryStatement2(
+            tryBlock,
+            [AstFactory.catchClause(
+                  name,
+                  [AstFactory.expressionStatement(
+                        AstFactory.methodInvocation2(
+                            catchName, [identifier(name)]))])]));
+  };
+
+  _translateDeclarationList(scanner.Keyword keyword,
+      ast.VariableDeclarationList node) => (f, s) {
+    translateDecl(ast.VariableDeclaration decl, cont) {
+      if (decl.initializer == null) {
+        return cont(decl);
+      } else {
+        return visit(decl.initializer)(f, (expr) {
+          return cont(AstFactory.variableDeclaration2(decl.name.name, expr));
+        });
+      }
+    }
+
+    var decls = [];
+    // The continuation for the last declaration.
+    var cont = (decl) {
+      decls.add(decl);
+      return s(decls);
+    };
+    for (var i = node.variables.length - 1; i >= 1; --i) {
+      var nextCont = cont;
+      // The continuation for the i-1 declaration.
+      cont = (decl) {
+        decls.add(decl);
+        var nextDecl = node.variables[i];
+        if (awaits.contains(nextDecl)) {
+          _residualizeDeclarationList(keyword, decls);
+          decls.clear();
+        }
+        translateDecl(nextDecl, nextCont);
+      };
+    }
+    translateDecl(node.variables.first, cont);
+  };
+
+  void _residualizeDeclarationList(scanner.Keyword keyword,
+      List<ast.VariableDeclaration> decls) {
+    if (decls.isEmpty) return;
+    addStatement(AstFactory.variableDeclarationStatement2(keyword, decls));
+  }
+
+  visitVariableDeclarationStatement(
+      ast.VariableDeclarationStatement node) => (f, r, s) {
+    var keyword = scanner.Keyword.keywords[node.variables.keyword.lexeme];
+    return _translateDeclarationList(keyword, node.variables)(f, (decls) {
+      _residualizeDeclarationList(keyword, decls);
+      return s();
+    });
+  };
+
+  visitWhileStatement(ast.WhileStatement node) => (f, r, s) {
+    var breakName = newName('break');
+    var continueName = newName('continue');
+
+    var savedBlock = currentBlock;
+    var breakBlock = currentBlock = emptyBlock();
+    s();
+
+    var continueBlock = currentBlock = emptyBlock();
+    visit(node.condition)(f, (expr) {
+      var savedBlock = currentBlock;
+      var bodyBlock = currentBlock = emptyBlock();
+      breakTargets.add(identifier(breakName));
+      continueTargets.add(identifier(continueName));
+      visit(node.body)(f, r, () {
+        addStatement(
+            AstFactory.functionExpressionInvocation(
+              identifier(continueName), [nullLiteral()]));
+      });
+      breakTargets.removeLast();
+      continueTargets.removeLast();
+
+      currentBlock = savedBlock;
+      addStatement(AstFactory.ifStatement2(
+        expr,
+        // Trampoline the body via Future.wait.
+        block([AstFactory.methodInvocation(
+            AstFactory.functionExpressionInvocation(
+                AstFactory.identifier(identifier('Future'),
+                                      identifier('wait')),
+                [AstFactory.listLiteral([])]),
+            'then',
+            [functionExpression(['_'], bodyBlock)])]),
+        block([AstFactory.functionExpressionInvocation(
+            identifier(breakName), [nullLiteral()])])));
+    });
+
+    currentBlock = savedBlock;
+    addStatement(
+        AstFactory.functionDeclarationStatement(null, null, breakName,
+            functionExpression(['_'], breakBlock)));
+    addStatement(
+        AstFactory.functionDeclarationStatement(null, null, continueName,
+            functionExpression(['_'], continueBlock)));
+    addStatement(
+        AstFactory.functionExpressionInvocation(
+            identifier(continueName), [nullLiteral()]));
+  };
+
+  visitYieldStatement(ast.YieldStatement node) => unimplemented(node);
+
+  // ---- Expressions ----
+  visitAsExpression(ast.AsExpression node) => unimplemented(node);
+
+  visitAssignmentExpression(ast.AssignmentExpression node) => (f, s) {
+    assert(node.leftHandSide is ast.SimpleIdentifier);
+    // TODO(kmillikin): handle compound assignments.
+    visit(node.rightHandSide)(f, (expr) {
+      return s(AstFactory.assignmentExpression(
+              node.leftHandSide, node.operator.type, expr));
+    });
+  };
+
+  visitAwaitExpression(ast.AwaitExpression node) => (f, s) {
+    if (awaits.contains(node.expression)) {
+      visit(node.expression)(f, (expr) {
+        addStatement(
             AstFactory.methodInvocation(
-                node.expression,
+                expr,
                 'then',
                 [reifyExpressionCont(s, f),
-                  AstFactory.namedExpression2('onError', owner.reifyErrorCont(f))]));
-      }
-    };
-  }
+                  AstFactory.namedExpression2('onError', reifyErrorCont(f))]));
+      });
+    } else {
+      addStatement(
+          AstFactory.methodInvocation(
+              node.expression,
+              'then',
+              [reifyExpressionCont(s, f),
+                AstFactory.namedExpression2('onError', reifyErrorCont(f))]));
+    }
+  };
 
-  ExpressionTransformer visitBinaryExpression(ast.BinaryExpression node) {
+  visitBinaryExpression(ast.BinaryExpression node) => (f, s) {
     // TODO: Is this even possible?
     assert(node.operator.lexeme != '||' && node.operator.lexeme != '&&');
-    return (ErrorCont f, ExpressionCont s) {
-      return visit(node.leftOperand)(f, (left) {
-        if (awaits.contains(node.rightOperand)) {
-          left = owner.addDeclaration('v', left);
-        }
-        return visit(node.rightOperand)(f, (right) {
-          s(AstFactory.binaryExpression(left, node.operator.type, right));
-        });
-      });
-    };
-  }
-
-  ExpressionTransformer visitBooleanLiteral(ast.BooleanLiteral node) {
-    return (ErrorCont f, ExpressionCont s) {
-      s(node);
-    };
-  }
-
-  ExpressionTransformer visitDoubleLiteral(ast.DoubleLiteral node) {
-    return (ErrorCont f, ExpressionCont s) {
-      s(node);
-    };
-  }
-
-  ExpressionTransformer visitFunctionExpression(ast.FunctionExpression node) {
-    return (ErrorCont f, ExpressionCont s) {
-      s(node);
-    };
-  }
-
-  ExpressionTransformer visitIndexExpression(ast.IndexExpression node) {
-    return (ErrorCont f, ExpressionCont s) {
-      visit(node.target)(f, (e0) {
-        if (awaits.contains(node.index)) {
-          e0 = owner.addDeclaration('v', e0);
-        }
-        visit(node.index)(f, (e1) {
-          s(AstFactory.indexExpression(e0, e1));
-        });
-      });
-    };
-  }
-
-  ExpressionTransformer visitInstanceCreationExpression(
-      ast.InstanceCreationExpression node) {
-    return (ErrorCont f, ExpressionCont s) {
-      translateExpressionList(node.argumentList.arguments)(f, (rands) {
-        s(AstFactory.instanceCreationExpression(
-            scanner.Keyword.keywords[node.keyword.lexeme],
-                node.constructorName,
-                rands));
-      });
-    };
-  }
-
-  ExpressionTransformer visitIntegerLiteral(ast.IntegerLiteral node) {
-    return (ErrorCont f, ExpressionCont s) {
-      s(node);
-    };
-  }
-
-  ExpressionTransformer visitListLiteral(ast.ListLiteral node) {
-    return (ErrorCont f, ExpressionCont s) {
-      translateExpressionList(node.elements)(f, (elts) {
-        s(AstFactory.listLiteral(elts));
-      });
-    };
-  }
-
-  ExpressionTransformer visitMapLiteral(ast.MapLiteral node) {
-    return (ErrorCont f, ExpressionCont s) {
-      var list = new ast.NodeList<ast.Expression>(node);
-      for (var entry in node.entries) {
-        list.add(entry.key);
-        list.add(entry.value);
+    return visit(node.leftOperand)(f, (left) {
+      if (awaits.contains(node.rightOperand)) {
+        left = addDeclaration('v', left);
       }
-      translateExpressionList(list)(f, (exprs) {
-        var entries = <ast.MapLiteralEntry>[];
-        for (var i = 0; i < exprs.length; i += 2) {
-          entries.add(new ast.MapLiteralEntry(
-              exprs[i],
-              TokenFactory.tokenFromType(scanner.TokenType.COLON),
-              exprs[i + 1]));
-        }
-        s(AstFactory.mapLiteral2(entries));
+      return visit(node.rightOperand)(f, (right) {
+        s(AstFactory.binaryExpression(left, node.operator.type, right));
       });
-    };
+    });
+  };
+
+  visitCascadeExpression(ast.CascadeExpression node) => unimplemented(node);
+
+  visitConditionalExpression(ast.ConditionalExpression node) {
+    unimplemented(node);
   }
 
-  ExpressionTransformer visitMethodInvocation(ast.MethodInvocation node) {
-    return (ErrorCont f, ExpressionCont s) {
-      if (node.target != null) {
-        visit(node.target)(f, (rator) {
-          translateExpressionList(node.argumentList.arguments)(f, (rands) {
-            s(AstFactory.methodInvocation(rator, node.methodName.name, rands));
-          });
-        });
+  visitFunctionExpression(ast.FunctionExpression node) => (f, s) {
+    // TODO(kmillikin): Handle async bodies.
+    return s(node);
+  };
+
+  visitFunctionExpressionInvocation(ast.FunctionExpressionInvocation node) {
+    unimplemented(node);
+  }
+
+  // ---- Identifiers ----
+  visitSimpleIdentifier(ast.SimpleIdentifier node) => (f, s) {
+    return s(node);
+  };
+
+  visitPrefixedIdentifier(ast.PrefixedIdentifier node) => (f, s) {
+    return s(node);
+  };
+
+  visitIndexExpression(ast.IndexExpression node) => (f, s) {
+    visit(node.target)(f, (e0) {
+      if (awaits.contains(node.index)) {
+        e0 = addDeclaration('v', e0);
+      }
+      visit(node.index)(f, (e1) {
+        s(AstFactory.indexExpression(e0, e1));
+      });
+    });
+  };
+
+  _translateExpressionList(ast.NodeList<ast.Expression> exprs) => (f, s) {
+    if (exprs.isEmpty) {
+      return s([]);
+    }
+    var args = [];
+    var seenAwait = false;
+    var cont = (v) {
+      args.add(v);
+      return s(args);
+    };
+    for (var i = exprs.length - 1; i >= 1; --i) {
+      var expr = exprs[i];
+      seenAwait = seenAwait || awaits.contains(expr);
+      var current = cont;
+      if (seenAwait) {
+        cont = (v) {
+          var value = addDeclaration('v', v);
+          args.add(value);
+          visit(expr)(f, current);
+        };
       } else {
-        translateExpressionList(node.argumentList.arguments)(f, (rands) {
-          s(AstFactory.methodInvocation2(node.methodName.name, rands));
-        });
+        cont = (v) {
+          args.add(v);
+          visit(expr)(f, current);
+        };
       }
-    };
-  }
+    }
+    return visit(exprs.first)(f, cont);
+  };
 
-  ExpressionTransformer visitNamedExpression(ast.NamedExpression node) {
-    return (ErrorCont f, ExpressionCont s) {
-      return visit(node.expression)(f, (expr) {
-        return s(AstFactory.namedExpression(node.name, expr));
-      });
-    };
-  }
+  visitInstanceCreationExpression(
+      ast.InstanceCreationExpression node) => (f, s) {
+    _translateExpressionList(node.argumentList.arguments)(f, (rands) {
+      s(AstFactory.instanceCreationExpression(
+              scanner.Keyword.keywords[node.keyword.lexeme],
+              node.constructorName,
+              rands));
+    });
+  };
 
-  ExpressionTransformer visitNullLiteral(ast.NullLiteral node) {
-    return (ErrorCont f, ExpressionCont s) {
-      s(node);
-    };
-  }
+  visitIsExpression(ast.IsExpression node) => unimplemented(node);
 
-  ExpressionTransformer visitParenthesizedExpression(
-        ast.ParenthesizedExpression node) {
-    return (ErrorCont f, ExpressionCont s) {
-      visit(node.expression)(f, s);
-    };
-  }
+  // ---- Literals ----
+  visitBooleanLiteral(ast.BooleanLiteral node) => (f, s) {
+    s(node);
+  };
 
-  ExpressionTransformer visitPrefixedIdentifier(ast.PrefixedIdentifier node) {
-    return (ErrorCont f, ExpressionCont s) {
-      s(node);
-    };
-  }
+  visitDoubleLiteral(ast.DoubleLiteral node) => (f, s) {
+    s(node);
+  };
 
-  ExpressionTransformer visitPropertyAccess(ast.PropertyAccess node) {
-    return (ErrorCont f, ExpressionCont s) {
-      return visit(node.target)(f, (expr) {
-        return s(AstFactory.propertyAccess(expr, node.propertyName));
-      });
-    };
-  }
+  visitIntegerLiteral(ast.IntegerLiteral node) => (f, s) {
+    s(node);
+  };
 
-  ExpressionTransformer visitSimpleStringLiteral(ast.SimpleStringLiteral node) {
-    return (ErrorCont f, ExpressionCont s) {
-      s(node);
-    };
-  }
+  visitNullLiteral(ast.NullLiteral node) => (f, s) {
+    return s(node);
+  };
 
-  ExpressionTransformer visitSimpleIdentifier(ast.SimpleIdentifier node) {
-    return (ErrorCont f, ExpressionCont s) {
-      s(node);
-    };
-  }
+  // ---- StringLiterals ----
+  visitAdjacentStrings(ast.AdjacentStrings node) => unimplemented(node);
 
-  ExpressionTransformer visitStringInterpolation(
-      ast.StringInterpolation node) {
-    return (ErrorCont f, ExpressionCont s) {
-      var list = new ast.NodeList<ast.Expression>(node);
+  visitSimpleStringLiteral(ast.SimpleStringLiteral node) => (f, s) {
+    return s(node);
+  };
+
+  visitStringInterpolation(ast.StringInterpolation node) => (f, s) {
+    var list = new ast.NodeList<ast.Expression>(node);
+    for (var element in node.elements) {
+      if (element is ast.InterpolationExpression) {
+        list.add(element.expression);
+      } else {
+        assert(element is ast.InterpolationString);
+      }
+    }
+    _translateExpressionList(list)(f, (exprs) {
+      var elements = <ast.InterpolationElement>[];
+      int index = 0;
       for (var element in node.elements) {
         if (element is ast.InterpolationExpression) {
-          list.add(element.expression);
+          elements.add(AstFactory.interpolationExpression(exprs[index++]));
         } else {
-          assert(element is ast.InterpolationString);
+          elements.add(element);
         }
       }
-      translateExpressionList(list)(f, (exprs) {
-        var elements = <ast.InterpolationElement>[];
-        int index = 0;
-        for (var element in node.elements) {
-          if (element is ast.InterpolationExpression) {
-            elements.add(AstFactory.interpolationExpression(exprs[index++]));
-          } else {
-            elements.add(element);
-          }
+      s(AstFactory.string(elements));
+    });
+  };
+
+  visitSymbolLiteral(ast.SymbolLiteral node) => (f, s) {
+    return s(node);
+  };
+
+  // ---- TypedLiterals ----
+  visitListLiteral(ast.ListLiteral node) => (f, s) {
+    _translateExpressionList(node.elements)(f, (elts) {
+      s(AstFactory.listLiteral(elts));
+    });
+  };
+
+  visitMapLiteral(ast.MapLiteral node) => (f, s) {
+    var list = new ast.NodeList<ast.Expression>(node);
+    for (var entry in node.entries) {
+      list.add(entry.key);
+      list.add(entry.value);
+    }
+    _translateExpressionList(list)(f, (exprs) {
+      var entries = <ast.MapLiteralEntry>[];
+      for (var i = 0; i < exprs.length; i += 2) {
+        entries.add(new ast.MapLiteralEntry(
+                exprs[i],
+                TokenFactory.tokenFromType(scanner.TokenType.COLON),
+                exprs[i + 1]));
+      }
+      s(AstFactory.mapLiteral2(entries));
+    });
+  };
+
+  visitMethodInvocation(ast.MethodInvocation node) => (f, s) {
+    if (node.target != null) {
+      visit(node.target)(f, (rator) {
+        if (awaits.contains(node.argumentList)) {
+          rator = addDeclaration('v', rator);
         }
-        s(AstFactory.string(elements));
+        _translateExpressionList(node.argumentList.arguments)(f, (rands) {
+          s(AstFactory.methodInvocation(rator, node.methodName.name, rands));
+        });
       });
-    };
-  }
+    } else {
+      _translateExpressionList(node.argumentList.arguments)(f, (rands) {
+        s(AstFactory.methodInvocation2(node.methodName.name, rands));
+      });
+    }
+  };
 
-  ExpressionTransformer visitSymbolLiteral(ast.SymbolLiteral node) {
-    return (ErrorCont f, ExpressionCont s) {
-      s(node);
-    };
-  }
+  visitNamedExpression(ast.NamedExpression node) => (f, s) {
+    return visit(node.expression)(f, (expr) {
+      return s(AstFactory.namedExpression(node.name, expr));
+    });
+  };
 
-  ExpressionTransformer visitThrowExpression(ast.ThrowExpression node) {
-    return (ErrorCont f, ExpressionCont s) {
-      visit(node.expression)(f, (e) => f(e));
-    };
-  }
+  visitParenthesizedExpression(ast.ParenthesizedExpression node) => (f, s) {
+    return visit(node.expression)(f, s);
+  };
+
+  visitPostfixExpression(ast.PostfixExpression node) => unimplemented(node);
+
+  visitPrefixExpression(ast.PrefixExpression node) => unimplemented(node);
+
+  visitPropertyAccess(ast.PropertyAccess node) => (f, s) {
+    return visit(node.target)(f, (expr) {
+      return s(AstFactory.propertyAccess(expr, node.propertyName));
+    });
+  };
+
+  visitSuperExpression(ast.SuperExpression node) => unimplemented(node);
+
+  visitThisExpression(ast.ThisExpression node) => unimplemented(node);
+
+  visitThrowExpression(ast.ThrowExpression node) => (f, s) {
+    return visit(node.expression)(f, (e) => f(e));
+  };
+
+  unreachable(node) => throw 'Unreachable(${node.runtimeType})';
+  visitAnnotation(node) => unreachable(node);
+  visitArgumentList(node) => unreachable(node);
+  visitComment(node) => unreachable(node);
+  visitCommentReference(node) => unreachable(node);
+  visitConstructorFieldInitializer(node) => unreachable(node);
+  visitConstructorName(node) => unreachable(node);
+  visitDeclaredIdentifier(node) => unreachable(node);
+  visitDefaultFormalParameter(node) => unreachable(node);
+  visitEnumConstantDeclaration(node) => unreachable(node);
+  visitExportDirective(node) => unreachable(node);
+  visitExtendsClause(node) => unreachable(node);
+  visitFieldFormalParameter(node) => unreachable(node);
+  visitFormalParameterList(node) => unreachable(node);
+  visitFunctionTypedFormalParameter(node) => unreachable(node);
+  visitHideCombinator(node) => unreachable(node);
+  visitImplementsClause(node) => unreachable(node);
+  visitImportDirective(node) => unreachable(node);
+  visitInterpolationExpression(node) => unreachable(node);
+  visitInterpolationString(node) => unreachable(node);
+  visitLabel(node) => unreachable(node);
+  visitLibraryDirective(node) => unreachable(node);
+  visitLibraryIdentifier(node) => unreachable(node);
+  visitMapLiteralEntry(node) => unreachable(node);
+  visitNativeClause(node) => unreachable(node);
+  visitPartDirective(node) => unreachable(node);
+  visitPartOfDirective(node) => unreachable(node);
+  visitRedirectingConstructorInvocation(node) => unreachable(node);
+  visitScriptTag(node) => unreachable(node);
+  visitShowCombinator(node) => unreachable(node);
+  visitSimpleFormalParameter(node) => unreachable(node);
+  visitSuperConstructorInvocation(node) => unreachable(node);
+  visitSwitchCase(node) => unreachable(node);
+  visitSwitchDefault(node) => unreachable(node);
+  visitTypeArgumentList(node) => unreachable(node);
+  visitTypeName(node) => unreachable(node);
+  visitTypeParameter(node) => unreachable(node);
+  visitTypeParameterList(node) => unreachable(node);
+  visitVariableDeclaration(node) => unreachable(node);
+  visitVariableDeclarationList(node) => unreachable(node);
+  visitWithClause(node) => unreachable(node);
 }


### PR DESCRIPTION
Combine the expressin translator and the other translator.  Extend the
abstract class AstVisitor instead of GeneralizingAstVisitor so that
there are no default implementations of visit methods.  Provide visit
implementations for all syntactic forms, including some
implementations that are 'unimplemented' or 'unreachable'.
