### PR TITLE
Add support for empty statements, prefix expression, assert, and is and ...

### DIFF
--- a/bin/async_await.dart
+++ b/bin/async_await.dart
@@ -17,14 +17,19 @@ main(List<String> args) {
 
   var errorListener = new ErrorCollector();
   var unit = _parse(new File(args.first), errorListener);
+  if (errorListener.errors.isNotEmpty) {
+    print("Errors:");
+    for (var error in errorListener.errors) {
+      print(error);
+    }
+    exit(1);
+  }
+
   var analysis = new AnalysisVisitor();
   analysis.visit(unit);
   var transform = new AsyncTransformer(analysis.awaits);
   print(transform.visit(unit));
 
-  for (var error in errorListener.errors) {
-    print(error);
-  }
 }
 
 _parse(File file, AnalysisErrorListener errorListener) {

--- a/tests/async/assert.dart
+++ b/tests/async/assert.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+
+f() async => true;
+g() async => () => true;
+
+main() async {
+  assert(await f());
+  ;
+  ;
+  ;
+  {}
+  {}
+  assert(await g());
+}
+

--- a/tests/async/is-and-as.dart
+++ b/tests/async/is-and-as.dart
@@ -1,0 +1,8 @@
+import 'dart:async';
+
+f() async => 42;
+
+main() async {
+  print(await f() is int);
+  print(await f() as int);
+}

--- a/tests/async/prefix.dart
+++ b/tests/async/prefix.dart
@@ -1,0 +1,18 @@
+import 'dart:async';
+
+class A {
+  var x;
+  A(this.x);
+}
+
+f() async => 42;
+g() async => true;
+h() async => new A(0);
+
+main() async {
+  print(!await g());
+  print(-await f() + 1);
+  print(~await f() + 1);
+  print(++(await h()).x);
+  print(--(await h()).x);
+}


### PR DESCRIPTION
...as.

Also modify the command-line driver to exit rather than translate
syntactically incorrect programs.
