### PR TITLE
Add Barback transformer.

### DIFF
--- a/lib/transformer.dart
+++ b/lib/transformer.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+
+import 'package:barback/barback.dart';
+
+import 'async_await.dart';
+
+/// A [Transformer] that runs the async/await compiler on any .dart files it
+/// finds.
+class AsyncAwaitTransformer extends Transformer implements LazyTransformer {
+  AsyncAwaitTransformer.asPlugin();
+
+  String get allowedExtensions => ".dart";
+
+  void declareOutputs(DeclaringTransform transform) {
+    // Just transforms a Dart file in place.
+    transform.declareOutput(transform.primaryId);
+  }
+
+  Future apply(Transform transform) {
+    return transform.primaryInput.readAsString().then((source) {
+      source = compile(source);
+      transform.addOutput(
+          new Asset.fromString(transform.primaryInput.id, source));
+    });
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,5 @@
 name: async_await
-description: A sample command-line application
+description: Compile-time support for "async/await" syntax in Dart.
 dependencies:
-  analyzer: any
+  analyzer: ">=0.22.3 <0.23.0"
+  barback: ">=0.15.0 <0.16.0"


### PR DESCRIPTION
This is just a minimal barback transformer wrapper for the compiler.

I also added a version range for the dependency on the analyzer. We'll definitely want that before we publish it. Otherwise, breaking changes to the analyzer will spontaneously break async_await.
