### PR TITLE
Add support for continue to a label.

### DIFF
--- a/tests/async/break_to_label.dart
+++ b/tests/async/break_to_label.dart
@@ -28,7 +28,7 @@ test2() async {
    print("bye");
 }
 
-test2() async {
+test3() async {
   var x = 0;
   here: do {
     x = x+1;
@@ -38,10 +38,21 @@ test2() async {
   print("bye");
 }
 
-test3() async {
+test4() async {
   here: for(var x = 0; x < 100; x = x+1) {
     if(x > 10) { break; }
     if(x > 20) { break here; }
   }
   print("bye");
+}
+
+test5() async {
+  var x = 0;
+  L0: while (x < 10) {
+    L1: while (x < 5) {
+      if (x != 0) break L0;
+      ++x;
+    }
+  }
+  return x;
 }

--- a/tests/async/continue.dart
+++ b/tests/async/continue.dart
@@ -1,0 +1,86 @@
+import 'dart:async';
+
+f(n) async => n;
+p(x) async { print(x); }
+
+test0() async {
+  var i = 0;
+  while (i < 10) {
+    await f(++i);
+    if (i.isOdd) continue;
+    await p(i);
+  }
+}
+
+test1() async {
+  var i = 0;
+  do {
+    await f(++i);
+    if (i.isOdd) continue;
+    await p(i);
+  } while (i < 10);
+}
+
+test2() async {
+  for (var i = 0; i < 10; ++i) {
+    await f(i);
+    if (i.isOdd) continue;
+    await p(i);
+  }
+}
+
+test3() async {
+  var i = 0;
+L0: while (i < 10) {
+    await f(++i);
+    var j = 0;
+ L1: while (j < 10) {
+      await f(++j);
+      if (j.isOdd) continue L0;
+      await p(j);
+    }
+    await p(i);
+  }
+}
+
+test4() async {
+  var i = 0;
+L0: do {
+    await f(++i);
+    var j = 0;
+ L1: while (j < 10) {
+      await f(++j);
+      if (j.isOdd) continue L0;
+      await p(j);
+    }
+    await p(i);
+  } while (i < 10);
+}
+
+test5() async {
+L0: for (var i = 0; i < 10; ++i) {
+    await f(i);
+    var j = 0;
+ L1: while (j < 10) {
+      await f(++j);
+      if (j.isOdd) continue L0;
+      await p(j);
+    }
+    await p(i);
+  }
+}
+
+test6() async {
+  var i = 0;
+  switch (i) {
+  L0: case 0:
+    await p(i);
+    continue L2;
+  L1: case 1:
+    await p(i);
+    continue L0;
+  L2: case 2:
+    await p(i);
+    continue L1;
+  }
+}


### PR DESCRIPTION
Also, move the handling of break targets for labeled loop switch
statements to the statements themselves instead of the labeled statement
enclosing them.
