### PR TITLE
Fix a bug in the pretty printing of string interpolation.

### DIFF
--- a/lib/src/pretty_printer.dart
+++ b/lib/src/pretty_printer.dart
@@ -492,16 +492,14 @@ class PrettyPrinter extends ast.RecursiveAstVisitor {
     if (node.elements.isEmpty) {
       buffer.write(']');
     } else {
-      if (node.elements.isNotEmpty) {
-        withContinuationIndentation(() {
-          buffer.writeln();
-          indent(() { visit(node.elements.first); });
-          for (var element in node.elements.skip(1)) {
-            buffer.writeln(',');
-            indent(() { visit(element); });
-          }
-        });
-      }
+      withContinuationIndentation(() {
+        buffer.writeln();
+        indent(() { visit(node.elements.first); });
+        for (var element in node.elements.skip(1)) {
+          buffer.writeln(',');
+          indent(() { visit(element); });
+        }
+      });
       buffer.writeln();
       indent(() { buffer.write(']'); });
     }


### PR DESCRIPTION
For string interpolation expressions, the `$` was printed twice if there
were braces surrounding the expression.

Also add a special case for empty map and list literals to pretty print
them without a newline before the opening and closing bracket or brace.
