### PR TITLE
Wrap the analyzer's AstFactory class.

### DIFF
--- a/lib/src/ast_factory.dart
+++ b/lib/src/ast_factory.dart
@@ -207,13 +207,17 @@ ast.NamedExpression namedExpression(label, ast.Expression expression) {
       : AstFactory.namedExpression(label, expression);
 }
 
-ast.InstanceCreationExpression newInstance(ast.Identifier constructor,
+ast.InstanceCreationExpression newInstance(ast.AstNode constructor,
     List<ast.Expression> arguments,
     [scanner.Keyword keyword = scanner.Keyword.NEW]) {
-  return AstFactory.instanceCreationExpression2(
-      keyword,
-      AstFactory.typeName3(constructor, []),
-      arguments);
+  if (constructor is ast.ConstructorName) {
+    return AstFactory.instanceCreationExpression(
+        keyword, constructor, arguments);
+  } else {
+    assert(constructor is ast.Identifier);
+    return AstFactory.instanceCreationExpression2(
+        keyword, AstFactory.typeName3(constructor, []), arguments);
+  }
 }
 
 ast.NullLiteral nullLiteral() {

--- a/lib/src/xform.dart
+++ b/lib/src/xform.dart
@@ -884,10 +884,10 @@ class AsyncTransformer extends ast.AstVisitor {
   visitIfStatement(ast.IfStatement node) => (r, s) {
     return visit(node.condition)((expr) {
       var savedBlock = currentBlock;
+      var joinName = newName('join');
       var joinBlock = currentBlock = make.emptyBlock();
       s();
 
-      var joinName = newName('join');
       s = () {
         addStatement(make.returnStatement(make.functionInvocation(joinName)));
       };
@@ -1331,11 +1331,11 @@ class AsyncTransformer extends ast.AstVisitor {
   visitBinaryExpression(ast.BinaryExpression node) => (s) {
     if (node.operator.lexeme == '&&' || node.operator.lexeme == '||') {
       if (awaits.contains(node.rightOperand)) {
+        var joinName = newName('join');
+        var joinParameterName = newName('x');
         visit(node.leftOperand)((left) {
           var savedBlock = currentBlock;
           var joinBlock = currentBlock = make.emptyBlock();
-          var joinName = newName('join');
-          var joinParameterName = newName('x');
           s(make.identifier(joinParameterName));
 
           var rightBlock = currentBlock = make.emptyBlock();
@@ -1411,9 +1411,9 @@ class AsyncTransformer extends ast.AstVisitor {
   visitConditionalExpression(ast.ConditionalExpression node) => (s) {
     return visit(node.condition)((expr) {
       var savedBlock = currentBlock;
-      var joinBlock = currentBlock = make.emptyBlock();
       var joinName = newName('join');
       var joinParameterName = newName('x');
+      var joinBlock = currentBlock = make.emptyBlock();
       s(make.identifier(joinParameterName));
 
       s = (r) {
@@ -1500,7 +1500,7 @@ class AsyncTransformer extends ast.AstVisitor {
   visitInstanceCreationExpression(
       ast.InstanceCreationExpression node) => (s) {
     _translateExpressionList(node.argumentList.arguments, (rands) {
-      s(make.newInstance(node.constructorName.name,
+      s(make.newInstance(node.constructorName,
                          rands,
                          scanner.Keyword.keywords[node.keyword.lexeme]));
     });


### PR DESCRIPTION
Provide our own API for constructing AST nodes rather than using the
analyzer's AstFactory from testing/ast_factory.dart.  Under the hood
it still uses the analyzer's AstFactory but it should be possible to
provide a direct implementation in terms of the AstNode constructors.
