### PR TITLE
Fix a bug in the translation of nested loops.

### DIFF
--- a/lib/src/xform.dart
+++ b/lib/src/xform.dart
@@ -803,8 +803,7 @@ class AsyncTransformer extends ast.AstVisitor {
     addStatement(
         make.functionDeclarationStatement(continueName, [], continueBlock));
     visit(node.body)(rk, ek, () {
-      addStatement(make.assignmentExpression(make.identifier(trampolineName),
-          make.identifier(continueName)));
+      _addTrampoline(trampolineName, make.identifier(continueName));
     });
 
     breakTargets = savedBreakTargets;
@@ -1093,8 +1092,7 @@ class AsyncTransformer extends ast.AstVisitor {
 
     var bodyBlock = currentBlock = make.emptyBlock();
     visit(node.body)(rk, ek, () {
-      addStatement(make.assignmentExpression(make.identifier(trampolineName),
-          make.identifier(continueName)));
+      _addTrampoline(trampolineName, make.identifier(continueName));
     });
 
     var loopBlock = currentBlock = make.emptyBlock();
@@ -1568,8 +1566,7 @@ class AsyncTransformer extends ast.AstVisitor {
       var savedBlock = currentBlock;
       var bodyBlock = currentBlock = make.emptyBlock();
       visit(node.body)(rk, ek, () {
-        addStatement(make.assignmentExpression(make.identifier(trampolineName),
-            make.identifier(continueName)));
+        _addTrampoline(trampolineName, make.identifier(continueName));
       });
 
       currentBlock = savedBlock;


### PR DESCRIPTION
When falling off the body of a loop, we used:

```
trampoline = continue;
```

and relied on an outer trampoline loop.  However it's possible to
reach the end of the body without being nested inside such a loop.
This happens in the case that there is an await from an inner
loop.

(An await in a loop will normally restore the loop in the .then
callback.  An await in an inner loop will only restore that innermost
loop in the .then callback.)

Instead, when falling off the body of the loop we need the full
trampoline:

```
trampoline = continue;
do trampoline(); while (trampoline != null);
```
