### PR TITLE
Allow enums in the input.

### DIFF
--- a/lib/src/compiler.dart
+++ b/lib/src/compiler.dart
@@ -18,6 +18,7 @@ CompilationUnit parse(String source, AnalysisErrorListener errorListener) {
   var token = scanner.tokenize();
   var parser = new Parser(null, errorListener);
   parser.parseAsync = true;
+  parser.parseEnum = true;
   return parser.parseCompilationUnit(token);
 }
 


### PR DESCRIPTION
Enum declarations do not contain the async modifier, so they are copied
unchanged into the output.  Uses of enum values of the form E.id will parse
as PrefixedIdentifiers, in which case the translation already handles them
correctly.

Enabling support simply requires setting the analyzer's flag to enable them.