### PR TITLE
Add a break statement to the end of each switch case.

### DIFF
--- a/lib/src/ast_factory.dart
+++ b/lib/src/ast_factory.dart
@@ -73,6 +73,10 @@ ast.Block emptyBlock() {
   return block([]);
 }
 
+ast.BreakStatement breakStatement() {
+  return AstFactory.breakStatement();
+}
+
 ast.DoStatement doStatement(ast.Statement body, ast.Expression condition) {
   return AstFactory.doStatement(body, condition);
 }

--- a/lib/src/xform.dart
+++ b/lib/src/xform.dart
@@ -1281,6 +1281,7 @@ class AsyncTransformer extends ast.AstVisitor {
               make.block([make.functionInvocation(continueNames[index])]);
           ++index;
         }
+        bodyBlock.statements.add(make.breakStatement());
         if (member is ast.SwitchDefault) {
           members.add(make.switchCase(null, bodyBlock.statements));
         } else {
@@ -1310,7 +1311,7 @@ class AsyncTransformer extends ast.AstVisitor {
       // names.  Otherwise, choose fresh names to avoid shadowing anything.
       if (clauses.length == 1) {
         var only = clauses.first;
-        exceptionName = currentExceptionName = 
+        exceptionName = currentExceptionName =
             only.exceptionParameter == null
                 ? newName('e')
                 : only.exceptionParameter.name;


### PR DESCRIPTION
The body of a switch case will normally end with a call in tail
position.  However, this causes warnings because the case does not end
with break, continue, return, or throw.  Solve the issue by manually
adding a break to the end of each switch case.