### PR TITLE
Handle failure of 'on T catch' clauses properly.

### DIFF
--- a/lib/src/xform.dart
+++ b/lib/src/xform.dart
@@ -1328,7 +1328,7 @@ class AsyncTransformer extends ast.AstVisitor {
       // clause is unconditional, it will orphan the previous clauses.  Base
       // case (the final else clause) is to rethrow the exception.
       catchBlock =
-          make.block([make.throwExpression(make.identifier(exceptionName))]);
+          make.block([ek.apply(exceptionName, stackTraceName)]);
       var savedBlock = currentBlock;
       for (var clause in clauses.reversed) {
         var bodyBlock = currentBlock = make.emptyBlock();


### PR DESCRIPTION
'on T catch' clauses are translated into if/else with explicit type
tests.  If all the tests fail the exception was thrown again, losing
the stack trace from the original exception.

Instead, use an explicit application of the error continuation (which
we already know there's an await).  This will either be a direct call
to Completer.completeError with two arguments, or a call to a local
catch handler function with two arguments.