### PR TITLE
Properly translate for-in and await for-in without a declaration keyword...

### DIFF
--- a/lib/src/ast_factory.dart
+++ b/lib/src/ast_factory.dart
@@ -9,6 +9,10 @@ import 'package:analyzer/src/generated/scanner.dart' as scanner;
 import 'package:analyzer/src/generated/testing/ast_factory.dart';
 
 // AST construction functions.
+scanner.Keyword keyword(scanner.Token token) {
+  if (token == null) return null;
+  return scanner.Keyword.keywords[token.lexeme];
+}
 
 // Create a function body from an expression, a single statement, or a block.
 ast.FunctionBody functionBody(ast.AstNode body) {

--- a/lib/src/xform.dart
+++ b/lib/src/xform.dart
@@ -851,7 +851,7 @@ class AsyncTransformer extends ast.AstVisitor {
       assert(node.loopVariable != null);
       body = make.block(
           [make.variableDeclarationStatement(
-              scanner.Keyword.keywords[node.loopVariable.keyword.lexeme],
+              make.keyword(node.loopVariable.keyword),
               [make.variableDeclaration(
                    node.loopVariable.identifier.name,
                    make.propertyAccess(make.identifier(it), 'current'))],
@@ -933,7 +933,7 @@ class AsyncTransformer extends ast.AstVisitor {
         } else {
           assert(node.loopVariable != null);
           addStatement(make.variableDeclarationStatement(
-              scanner.Keyword.keywords[node.loopVariable.keyword.lexeme],
+              make.keyword(node.loopVariable.keyword),
               [make.variableDeclaration(
                    node.loopVariable.identifier.name,
                    make.identifier(parameter))],
@@ -1519,10 +1519,7 @@ class AsyncTransformer extends ast.AstVisitor {
 
   visitVariableDeclarationStatement(
       ast.VariableDeclarationStatement node) => (rk, ek, sk) {
-    var keyword;
-    if (node.variables.keyword != null) {
-      keyword = scanner.Keyword.keywords[node.variables.keyword.lexeme];
-    }
+    var keyword = make.keyword(node.variables.keyword);
     var type = node.variables.type;
     return _translateDeclarationList(keyword, type, node.variables, ek,
         (decls) {


### PR DESCRIPTION
....

If a for-in loop variable is declared with a type and without a keyword,
e.g., 'var', then we did not translate it correctly.